### PR TITLE
Added accessibility. Fixed icon attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Or [download as ZIP](https://github.com/webcomponents/world-flag-polymer/archive
 Attribute           | Options                           | Default               | Description
 ---                 | ---                               | ---                   | ---
 `language`          | *string*                          | `en`                  | Standard i18n short-name
+`languageLong`      | *string*                          | `English`             | Long, human readable name of the language
 `icon`              | *boolean*                         | `true`                | Icon visibility
 `size`              | *string* 'small, medium, large'   | `''`                  | Icon size
 `type`              | *boolean*                         | `''`                  | Icon display style

--- a/dist/world-flag.html
+++ b/dist/world-flag.html
@@ -1,8 +1,8 @@
 <!-- Import Polymer -->
-<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../../polymer/polymer.html">
 
 <!-- Define your custom element -->
-<polymer-element name="world-flag" attributes="language icon size type">
+<polymer-element name="world-flag" attributes="language languageLong icon size type">
 
     <template>
         <style type="text/css">
@@ -42,7 +42,7 @@
             }
         </style>
         <div class="{{type || 'circle'}} {{size}}" role="i18nLang">
-            <img id="icon" src="flags/{{language}}.png" width="{{setImgSize}}" />
+            <img id="icon" src="flags/{{language}}.png" width="{{setImgSize}}" alt="{{languageLong}}" />
             <p>{{language}}</p>
         </div>
     </template>
@@ -50,12 +50,13 @@
     <script>
         Polymer('world-flag', {
             language: 'en',
+            languageLong: 'English',
             ready: function(){
                 this.setImgSize = this.setSize();
                 this.setIcon();
             },
             setIcon: function(){
-                if(this.icon){ this.$.icon.remove(); }
+                if(this.icon === 'false'){ this.$.icon.remove(); }
             },
             setSize: function(){
                 var size;

--- a/index.html
+++ b/index.html
@@ -55,13 +55,13 @@
     <div class="demo">
         <!-- Using Custom Elements -->
         <span>Custom language:</span><code>language="es"</code>
-        <world-flag language="es"></world-flag>
+        <world-flag language="es" languageLong="España"></world-flag>
     </div>
 
     <div class="demo">
         <!-- Using Custom Elements -->
         <span>Modes:</span><code>language="es_ar" <br> icon="false"</code>
-        <world-flag language="es_ar" icon="true"></world-flag>
+        <world-flag language="es_ar" languageLong="Argentina" icon="false"></world-flag>
     </div>
 
     <div class="demo">
@@ -69,26 +69,26 @@
         <span>Sizes:</span>
 
         <code>size="small"</code>
-        <world-flag language="pt_br" size="small"></world-flag>
+        <world-flag language="pt_br" languageLong="República Federativa do Brasil" size="small"></world-flag>
 
         <code>size="medium"</code>
-        <world-flag language="pt_br" size="medium"></world-flag>
+        <world-flag language="pt_br" languageLong="República Federativa do Brasil" size="medium"></world-flag>
 
         <code>default</code>
-        <world-flag language="pt_br"></world-flag>
+        <world-flag language="pt_br" languageLong="República Federativa do Brasil"></world-flag>
 
         <code>size="large"</code>
-        <world-flag language="pt_br" size="large"></world-flag>
+        <world-flag language="pt_br" languageLong="República Federativa do Brasil" size="large"></world-flag>
     </div>
 
     <div class="demo">
         <!-- Using Custom Elements -->
         <span>Style:</span>
         <code>type="normal"</code>
-        <world-flag language="en_gb" type="normal"></world-flag>
+        <world-flag language="en_gb" languageLong="English" type="normal"></world-flag>
 
         <code>default</code>
-        <world-flag language="en_gb"></world-flag>
+        <world-flag language="en_gb"  languageLong="English"></world-flag>
 
         <!--
         <code>list</code>

--- a/src/world-flag.html
+++ b/src/world-flag.html
@@ -2,7 +2,7 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
 
 <!-- Define your custom element -->
-<polymer-element name="world-flag" attributes="language icon size type">
+<polymer-element name="world-flag" attributes="language languageLong icon size type">
 
     <template>
         <style type="text/css">
@@ -42,7 +42,7 @@
             }
         </style>
         <div class="{{type || 'circle'}} {{size}}" role="i18nLang">
-            <img id="icon" src="flags/{{language}}.png" width="{{setImgSize}}" />
+            <img id="icon" src="flags/{{language}}.png" width="{{setImgSize}}" alt="{{languageLong}}" />
             <p>{{language}}</p>
         </div>
     </template>
@@ -50,12 +50,13 @@
     <script>
         Polymer('world-flag', {
             language: 'en',
+            languageLong: 'English',
             ready: function(){
                 this.setImgSize = this.setSize();
                 this.setIcon();
             },
             setIcon: function(){
-                if(this.icon){ this.$.icon.remove(); }
+                if(this.icon === 'false'){ this.$.icon.remove(); }
             },
             setSize: function(){
                 var size;


### PR DESCRIPTION
Icons did not have an alt attribute which means users on screen readers would not get the same information.  For uniformity, I created a new attribute, 'languageLong' for the alt attribute.  In a final implementation, the user will need to add any arbitrary string depending on their intended use. For instance, if the flag is the UK flag and they intend it to refer to the UK, then they should be able to put "United Kingtom" in there. But if they intend it to mean "British English" then they can enter that.  The language/ languageLong attributes are a little misleadingly named, but at least it consistent.

Also, I fixed the 'icon' attribute.   Reading the code, it seemed as though `icon=false` is supposed to disable (remove) the icon. If that's the case, the way you had it basically meant that _any_ value of `icon` would remove it. So, I fixed that.
